### PR TITLE
Fix link to config service

### DIFF
--- a/webapp/app.js
+++ b/webapp/app.js
@@ -88,7 +88,7 @@ function run($rootScope) {
 angular.element(document).ready(function () {
     var initInjector = angular.injector(["ng"]);
     var $http = initInjector.get("$http");
-    $http.get("/api/config").then(response => {
+    $http.get(document.location + "api/config").then(response => {
         app.constant("rawConfig", response.data);
         angular.bootstrap(document, ["app"]);
     });


### PR DESCRIPTION
In a reverse proxy environment, it was trying to access to
/api/config when evebox is served under /evebox/.