### PR TITLE
frontend: elastic search query fix

### DIFF
--- a/webapp/src/reports/ip-report/ip-report.component.ts
+++ b/webapp/src/reports/ip-report/ip-report.component.ts
@@ -187,7 +187,8 @@ export class IpReportComponent implements OnInit, OnDestroy {
                     should: [
                         termQuery(ipTermType, "src_ip", this.ip),
                         termQuery(ipTermType, "dest_ip", this.ip),
-                    ]
+                    ],
+                    "minimum_should_match" : 1
                 }
             },
             size: 0,


### PR DESCRIPTION
IP report was not filtering on IP because a parameter was missing
in the query.