### PR TITLE
add required script-loader

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -41,7 +41,8 @@
     "rxjs": "^5.1.0",
     "toastr": "^2.1.2",
     "ts-helpers": "^1.1.1",
-    "zone.js": "^0.8.4"
+    "zone.js": "^0.8.4",
+    "script-loader": "^0.7.1"
   },
   "devDependencies": {
     "@angular/cli": "^1.1.2",


### PR DESCRIPTION
while building the package then there is requirement script-loader in webapp/src/main.ts and webapp/src/app/humanize.service.ts which is not included in package.json and makes build to fail