### PR TITLE
evebox.yaml.example: miss-spelled database name

### DIFF
--- a/evebox.yaml.example
+++ b/evebox.yaml.example
@@ -77,7 +77,7 @@ database:
     # PostgreSQL port (default: 5432; env: PGPORT)
     #port:
 
-    # Database name (default: eveobox; env: PGDATABASE)
+    # Database name (default: evebox; env: PGDATABASE)
     #database:
 
     # Database user (default: evebox; env: PGUSER)


### PR DESCRIPTION
postgres default database name was spelled eveobox instead of evebox

