### PR TITLE
Update RPM packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,8 +135,8 @@ rpm:
 	    --rpm-attr 0644,root,root:/lib/systemd/system/evebox.service \
 	    --rpm-attr 0644,root,root:/lib/systemd/system/evebox-agent.service \
 	    --rpm-attr 0755,root,root:/usr/bin/evebox \
-	    --rpm-attr 0644,root,root:/etc/evebox/evebox.yaml.example \
-	    --rpm-attr 0644,root,root:/etc/evebox/agent.yaml.example \
+	    --rpm-attr 0640,root,evebox:/etc/evebox/evebox.yaml.example \
+	    --rpm-attr 0640,root,evebox:/etc/evebox/agent.yaml.example \
 	    --rpm-attr 0644,root,root:/etc/sysconfig/evebox.service \
 	    ${EVEBOX_BIN}=/usr/bin/evebox \
 	    examples/evebox.yaml=/etc/evebox/evebox.yaml.example \

--- a/Makefile
+++ b/Makefile
@@ -132,15 +132,17 @@ rpm:
 	    --before-install=rpm/before-install.sh \
 	    --after-upgrade=rpm/after-upgrade.sh \
 	    --config-files /etc/sysconfig/evebox \
+	    --config-files /etc/evebox/exebox.yaml \
+	    --config-files /etc/evebox/agen.yaml \
 	    --rpm-attr 0644,root,root:/lib/systemd/system/evebox.service \
 	    --rpm-attr 0644,root,root:/lib/systemd/system/evebox-agent.service \
 	    --rpm-attr 0755,root,root:/usr/bin/evebox \
-	    --rpm-attr 0640,root,evebox:/etc/evebox/evebox.yaml.example \
-	    --rpm-attr 0640,root,evebox:/etc/evebox/agent.yaml.example \
-	    --rpm-attr 0644,root,root:/etc/sysconfig/evebox.service \
+	    --rpm-attr 0640,root,evebox:/etc/evebox/evebox.yaml \
+	    --rpm-attr 0640,root,evebox:/etc/evebox/agent.yaml \
+	    --rpm-attr 0644,root,root:/etc/sysconfig/evebox \
 	    ${EVEBOX_BIN}=/usr/bin/evebox \
-	    examples/evebox.yaml=/etc/evebox/evebox.yaml.example \
-	    examples/agent.yaml=/etc/evebox/agent.yaml.example \
+	    examples/evebox.yaml=/etc/evebox/evebox.yaml \
+	    examples/agent.yaml=/etc/evebox/agent.yaml \
 	    rpm/evebox.sysconfig=/etc/sysconfig/evebox \
 	    rpm/evebox.service=/lib/systemd/system/evebox.service \
 	    rpm/evebox-agent.service=/lib/systemd/system/evebox-agent.service

--- a/Makefile
+++ b/Makefile
@@ -138,11 +138,15 @@ rpm:
 	    --rpm-attr 0644,root,root:/lib/systemd/system/evebox-agent.service \
 	    --rpm-attr 0755,root,root:/usr/bin/evebox \
 	    --rpm-attr 0640,root,evebox:/etc/evebox/evebox.yaml \
+	    --rpm-attr 0640,root,evebox:/etc/evebox/evebox.yaml.example \
 	    --rpm-attr 0640,root,evebox:/etc/evebox/agent.yaml \
+	    --rpm-attr 0640,root,evebox:/etc/evebox/agent.yaml.example \
 	    --rpm-attr 0644,root,root:/etc/sysconfig/evebox \
 	    ${EVEBOX_BIN}=/usr/bin/evebox \
 	    examples/evebox.yaml=/etc/evebox/evebox.yaml \
+	    examples/evebox.yaml=/etc/evebox/evebox.yaml.example \
 	    examples/agent.yaml=/etc/evebox/agent.yaml \
+	    examples/agent.yaml=/etc/evebox/agent.yaml.example \
 	    rpm/evebox.sysconfig=/etc/sysconfig/evebox \
 	    rpm/evebox.service=/lib/systemd/system/evebox.service \
 	    rpm/evebox-agent.service=/lib/systemd/system/evebox-agent.service


### PR DESCRIPTION
This tries to do a few things:
* Set better permissions on config files
* Fix an apparent typo for /etc/sysconfig/evebox
* Mark config files as config files so they are not replaced on upgrade
* Actually own the real config file
This is untested as I don't have the ability to build evebox and evebox RPMs with fpm at the moment.