### PR TITLE
server: Add support for reading eve-log through unix socket file

### DIFF
--- a/examples/agent.yaml
+++ b/examples/agent.yaml
@@ -40,6 +40,12 @@ input:
     - "/var/log/suricata/eve.json"
     - "/var/log/suricata/eve.*.json"
 
+  # Suricata can write the EVE log to a unix stream socket by specifying
+  # the eve-log filetype attribute as 'unix_stream' instead of 'regular'.
+  # EveBox will create the sockets below and listen for events once connected.
+  #sockets:
+  #  - "/var/log/suricata/eve.log.socket"
+
 # Additional fields that will be added to each event. This is currently limited
 # to strings at this time.
 additional-fields:

--- a/examples/evebox.yaml
+++ b/examples/evebox.yaml
@@ -100,6 +100,12 @@ input:
   #  - /usr/share/suricata/rules/*.rules
   #  - /etc/suricata/rules/*.rules
 
+  # Suricata can write the EVE log to a unix stream socket by specifying
+  # the eve-log filetype attribute as 'unix_stream' instead of 'regular'.
+  # EveBox will create the sockets below and listen for events once connected.
+  #sockets:
+  #  - "/var/log/suricata/eve.log.socket"
+
 geoip:
   disabled: false
   # Path to the MaxMind database. This must be the version 2 database

--- a/src/bookmark.rs
+++ b/src/bookmark.rs
@@ -73,7 +73,7 @@ impl Bookmark {
 
     #[cfg(not(unix))]
     fn check_inode(&self, _meta: &std::fs::Metadata) -> bool {
-        return true;
+        true
     }
 }
 

--- a/src/cli/oneshot.rs
+++ b/src/cli/oneshot.rs
@@ -5,6 +5,7 @@ use crate::prelude::*;
 
 use crate::config::Config;
 use crate::eve;
+use crate::eve::EveReader;
 use crate::geoip;
 use crate::server::main::build_axum_service;
 use crate::server::metrics::Metrics;
@@ -171,7 +172,7 @@ async fn run_import(
 ) -> anyhow::Result<()> {
     let geoipdb = geoip::GeoIP::open(None).ok();
     let mut indexer = sqlite::importer::SqliteEventSink::new(sqlx, writer, metrics);
-    let mut reader = eve::reader::EveReader::new(input.into());
+    let mut reader = eve::reader::EveReaderFile::new(input.into());
     info!("Reading {} ({} bytes)", input, reader.file_size());
     let mut last_percent = 0;
     let mut count = 0;

--- a/src/eve/mod.rs
+++ b/src/eve/mod.rs
@@ -11,3 +11,7 @@ pub(crate) mod watcher;
 pub(crate) use eve::Eve;
 pub(crate) use processor::Processor;
 pub(crate) use reader::EveReader;
+pub(crate) use reader::EveReaderError;
+pub(crate) use reader::EveReaderFile;
+#[cfg(unix)]
+pub(crate) use reader::EveReaderSocket;


### PR DESCRIPTION
This change makes it possible to use Suricata's unix_stream output for the eve log. Suricata acts as the client and does not create a socket file, so EveBox takes on the server role of creating a socket file in `EveReader::open` and then accepting a connection, if not already established, in `EveReader::next_record()`.

It has only been tested on linux with sqlite backend, not elasticsearch.

The code change overview is:
- EveReader is now a trait that EveReaderFile (renamed from EveReader) and EveReaderSocket implement
- Processor is type-parametrized to work with either reader
- Starting a Processor for a unix socket as specified in yaml config is done by server and agent. It does not really make sense in oneshot

I am just starting to learn rust and any advice on using the language or how you would like to see this feature implemented differently is very welcome. For one, it is ugly to see the EveReader trait specify seeking functions that are only used for bookmarks when it cannot apply to sockets.
