### PR TITLE
packaging: create /var/lib/evebox directory in debian after-install script

### DIFF
--- a/packaging/debian/after-install.sh
+++ b/packaging/debian/after-install.sh
@@ -13,3 +13,10 @@ if ! /usr/bin/getent passwd ${USERNAME} > /dev/null; then
             --shell /usr/sbin/nologin \
             ${USERNAME}
 fi
+
+# Create the data directory if it doesn't exist
+if [ ! -d ${HOMEDIR} ]; then
+    mkdir -p ${HOMEDIR}
+    chown ${USERNAME}:${USERNAME} ${HOMEDIR}
+    chmod 750 ${HOMEDIR}
+fi


### PR DESCRIPTION
## Summary
- Fix debian package installation by creating the `/var/lib/evebox` directory
- The package creates the evebox user with `/var/lib/evebox` as home directory but doesn't create the actual directory
- Both evebox and evebox-agent systemd services expect `EVEBOX_DATA_DIRECTORY=/var/lib/evebox` to exist

## Test plan
- [ ] Test debian package installation on clean system
- [ ] Verify `/var/lib/evebox` directory is created with correct ownership
- [ ] Confirm evebox services can start successfully after installation

Fixes #346