### PR TITLE
ci: restrict workflow permissions to read-only

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   cargo-test:


### PR DESCRIPTION
## Summary
- Add explicit permissions block to GitHub Actions workflow to restrict GITHUB_TOKEN to read-only access
- Resolves CodeQL security alerts #1-5 by following the principle of least privilege