### PR TITLE
Add --default-time-range CLI option

### DIFF
--- a/src/bin/evebox.rs
+++ b/src/bin/evebox.rs
@@ -247,6 +247,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .help("Disable GeoIP"),
         )
         .arg(
+            Arg::new("defaults.time-range")
+                .long("default-time-range")
+                .action(ArgAction::Set)
+                .value_name("RANGE")
+                .help("Default time range (e.g., '24h', '7d', 'all')"),
+        )
+        .arg(
             Arg::new("input.paths")
                 .value_name("EVE")
                 .num_args(0..)

--- a/src/server/main.rs
+++ b/src/server/main.rs
@@ -152,6 +152,11 @@ pub async fn main(args: &clap::ArgMatches) -> Result<()> {
     let mut context =
         build_context(server_config.clone(), datastore, configdb, metrics.clone()).await?;
 
+    // Set default time range if provided via CLI or config
+    if let Ok(Some(time_range)) = config.get::<String>("defaults.time-range") {
+        context.defaults.time_range = Some(time_range);
+    }
+
     if server_config.authentication_required && !context.configdb.has_users().await? {
         warn!("Username/password authentication is required, but no users exist, creating a user");
         let (username, password) = create_admin_user(&context).await?;


### PR DESCRIPTION
For oneshot or training environments, it's useful to set a default time range (like "all") without modifying config files. This adds a `--default-time-range` command-line option for the server command.

## What Changed

- Add `--default-time-range` argument to server command
- Read `defaults.time-range` from config and apply to context
- Validation is delegated to existing `parse_duration` function which handles values like '24h', '7d', 'all'

This allows operators to override the default time range at startup without config file changes.

Fixes #237