### PR TITLE
pcap: allow choosing download filenames

### DIFF
--- a/src/server/api/eve2pcap.rs
+++ b/src/server/api/eve2pcap.rs
@@ -20,6 +20,7 @@ use crate::error::AppError;
 pub(crate) struct PcapForm {
     pub what: String,
     pub event: String,
+    pub filename: Option<String>,
 }
 
 pub(crate) async fn handler(
@@ -37,19 +38,135 @@ pub(crate) async fn handler(
         .map_err(|err| AppError::BadRequest(format!("failed to decode event: {err}")))?;
 
     let pcap_buffer = pcap::eve_to_pcap(&form.what, &event)?;
-    let filename = generate_filename(&event);
+    let filename = generate_filename(&event, form.filename.as_deref());
 
-    let cs_hdr_value = format!("attachment; filename={filename}.pcap");
+    let cs_hdr_value = format!("attachment; filename=\"{filename}.pcap\"");
     hmap.insert(CONTENT_DISPOSITION, cs_hdr_value.parse().unwrap());
 
     Ok((hmap, pcap_buffer))
 }
 
-/// Generate a filename for the PCAP file based on the event
-fn generate_filename(event: &serde_json::Value) -> String {
+/// Generate a filename for the PCAP file based on user input or the event.
+fn generate_filename(event: &serde_json::Value, requested_filename: Option<&str>) -> String {
+    if let Some(filename) = requested_filename.and_then(sanitize_filename) {
+        return filename;
+    }
+
+    generate_default_filename(event)
+}
+
+fn generate_default_filename(event: &serde_json::Value) -> String {
     if let Some(sid) = &event["alert"]["signature_id"].as_u64() {
+        if let Some(app_proto) = event["app_proto"].as_str().and_then(sanitize_filename) {
+            return format!("{sid}-{app_proto}");
+        }
         sid.to_string()
     } else {
         "event".to_string()
+    }
+}
+
+fn sanitize_filename(filename: &str) -> Option<String> {
+    let mut filename = filename.trim();
+    if filename.len() >= 5 && filename[filename.len() - 5..].eq_ignore_ascii_case(".pcap") {
+        filename = &filename[..filename.len() - 5];
+    }
+
+    let mut sanitized = String::new();
+    let mut last_was_separator = false;
+    for c in filename.chars() {
+        let next = if c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-' {
+            last_was_separator = false;
+            Some(c)
+        } else if c.is_whitespace() || c == '/' || c == '\\' || c.is_control() {
+            if last_was_separator {
+                None
+            } else {
+                last_was_separator = true;
+                Some('-')
+            }
+        } else if last_was_separator {
+            None
+        } else {
+            last_was_separator = true;
+            Some('-')
+        };
+
+        if let Some(c) = next {
+            sanitized.push(c);
+        }
+    }
+
+    let sanitized = sanitized.trim_matches(['.', '-', '_']).to_string();
+    if sanitized.is_empty() {
+        None
+    } else {
+        Some(sanitized)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::generate_filename;
+
+    #[test]
+    fn generate_filename_uses_requested_filename_when_available() {
+        let event = json!({
+            "app_proto": "dns",
+            "alert": {
+                "signature_id": 12345,
+            }
+        });
+
+        assert_eq!(
+            "custom-capture",
+            generate_filename(&event, Some("custom-capture"))
+        );
+    }
+
+    #[test]
+    fn generate_filename_strips_pcap_extension_from_requested_filename() {
+        let event = json!({});
+
+        assert_eq!(
+            "custom-capture",
+            generate_filename(&event, Some("custom-capture.pcap"))
+        );
+    }
+
+    #[test]
+    fn generate_filename_sanitizes_requested_filename() {
+        let event = json!({});
+
+        assert_eq!(
+            "custom-capture",
+            generate_filename(&event, Some("../custom\rcapture"))
+        );
+    }
+
+    #[test]
+    fn generate_filename_falls_back_when_requested_filename_is_blank() {
+        let event = json!({
+            "app_proto": "dns",
+            "alert": {
+                "signature_id": 12345,
+            }
+        });
+
+        assert_eq!("12345-dns", generate_filename(&event, Some("  ")));
+    }
+
+    #[test]
+    fn generate_filename_includes_sid_and_app_proto_when_available() {
+        let event = json!({
+            "app_proto": "dns",
+            "alert": {
+                "signature_id": 12345,
+            }
+        });
+
+        assert_eq!("12345-dns", generate_filename(&event, None));
     }
 }

--- a/webapp/src/EventView.tsx
+++ b/webapp/src/EventView.tsx
@@ -624,7 +624,13 @@ export function EventView() {
 
   function eventToPcap(what: "packet" | "payload") {
     if (event()) {
-      API.eventToPcap(event()!, what);
+      const filename = window.prompt(
+        "Save PCAP as",
+        `${API.pcapFilename(event()!)}.pcap`,
+      );
+      if (filename !== null) {
+        API.eventToPcap(event()!, what, filename);
+      }
     }
   }
 

--- a/webapp/src/api.ts
+++ b/webapp/src/api.ts
@@ -406,9 +406,19 @@ export namespace API {
     return post(`api/event/${event._id}/de-escalate`);
   }
 
+  export function pcapFilename(event: EventWrapper): string {
+    const source = event._source;
+    const sid = source.alert?.signature_id;
+    if (sid) {
+      return source.app_proto ? `${sid}-${source.app_proto}` : `${sid}`;
+    }
+    return "event";
+  }
+
   export async function eventToPcap(
     event: EventWrapper,
     what: "packet" | "payload",
+    filename?: string,
   ) {
     const form = document.createElement("form") as HTMLFormElement;
     form.setAttribute("method", "post");
@@ -425,6 +435,14 @@ export namespace API {
     eventField.setAttribute("name", "event");
     eventField.setAttribute("value", JSON.stringify(event._source));
     form.appendChild(eventField);
+
+    if (filename) {
+      const filenameField = document.createElement("input") as HTMLElement;
+      filenameField.setAttribute("type", "hidden");
+      filenameField.setAttribute("name", "filename");
+      filenameField.setAttribute("value", filename);
+      form.appendChild(filenameField);
+    }
 
     document.body.appendChild(form);
     form.submit();


### PR DESCRIPTION
## Summary
- prompt for a PCAP filename before downloading packet or payload PCAPs
- submit the chosen filename to the eve2pcap endpoint and use it in Content-Disposition
- keep the SID/app-proto generated filename as the default suggestion and fallback
- sanitize requested filenames server-side and avoid double `.pcap` extensions
- add regression tests for requested filename handling and fallback behavior

## Test Plan
- `cargo test server::api::eve2pcap::tests::`
- `cargo fmt --check`
- `cargo test`
- `cd webapp && npx prettier --check src/EventView.tsx src/api.ts`
- `cd webapp && npm run build` (with generated `src/gitrev.ts`)

Closes #321
