### PR TITLE
oneshot local suricata

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -31,6 +31,17 @@ jobs:
       - run: git config --global --add safe.directory /__w/evebox/evebox
       - run: cargo test --all
 
+  windows-test:
+    name: Native Windows Tests
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - run: cargo test --all
+
   msrv-check:
     name: Check MSRV
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,37 @@
 ## Unreleased
 
 ### Added
+- Oneshot PCAP mode can now use a locally installed Suricata instead of a
+  container. Rules are downloaded with `suricata-update` when available, or
+  directly from the supported rule feeds when it is absent, with downloads
+  cached in EveBox's cache directory. The local backend is the default on
+  Windows and is selected on Linux with `--suricata-backend local` or
+  `--suricata`, and is also used on Linux as a fallback when no usable
+  container runtime is found. Configuration, rules, and logs are generated
+  in a temporary workspace, leaving the installed Suricata configuration
+  untouched. The generated configuration enables all protocol loggers,
+  including those disabled by default in Suricata, with extended logging
+  and file hashing enabled. On Windows, rules using the `file.magic` or
+  `filemagic` keywords are removed when assembling the ruleset, as the
+  Windows Suricata builds do not support them. Windows supports analysis and
+  event import, but not packet extraction from the input PCAP.
 - Oneshot mode can now read EVE events from stdin by using `-` as the
   input, for example: `curl https://example.com/eve.json | evebox oneshot -`.
   Events are imported as they arrive rather than waiting for end of input.
   https://github.com/jasonish/evebox/issues/374
 
 ### Changed
+- Oneshot PCAP processing no longer aborts when individual rules fail to
+  load. Suricata now logs and skips such rules, and processing continues
+  with the rules that did load.
 - In oneshot mode, `CTRL-C` while events are still being imported now stops
   the import, keeping the events read so far for review. A further `CTRL-C`
   exits.
+- The oneshot database is now created in the EveBox cache directory instead
+  of the current directory, and stale database files left behind by a
+  previous run are removed on startup. Previously, on Windows, the database
+  could not be removed on exit and a later run would also show the previous
+  run's events.
 
 ## 0.27.0 - 2026-07-19
 
@@ -24,7 +46,7 @@
   `defaults.time-range` configuration key.
 - `evebox oneshot --pcap` can process one or more local PCAP files with
   containerized Suricata before loading the generated EVE events. On Linux
-  it uses local Podman or Docker with ET/Open, PawPatRules, and The Hunters
+  it uses local Podman or Docker with ET/Open, PAW Patrules, and The Hunters
   Ledger rules.
 - Oneshot mode shows compact event-type count cards above the event list for
   quickly reviewing and filtering imported events.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
@@ -93,13 +99,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -259,9 +265,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -273,6 +279,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -299,15 +314,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -337,15 +352,15 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -353,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -365,14 +380,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -411,6 +426,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
@@ -458,6 +479,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,19 +503,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
+name = "crc32fast"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -493,7 +532,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -525,6 +564,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,7 +584,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -566,7 +614,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -575,10 +623,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -610,7 +669,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -707,6 +766,7 @@ dependencies = [
  "clap",
  "directories",
  "filetime",
+ "flate2",
  "futures",
  "gethostname",
  "glob",
@@ -724,7 +784,7 @@ dependencies = [
  "owo-colors",
  "pcap",
  "percent-encoding",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rcgen",
  "regex",
  "reqwest",
@@ -738,6 +798,7 @@ dependencies = [
  "serde_yaml",
  "sqlx",
  "suricatax-rule-parser",
+ "tar",
  "tempfile",
  "thiserror",
  "time",
@@ -768,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "filetime"
@@ -787,6 +848,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -832,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -847,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -857,15 +928,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -885,38 +956,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -994,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
@@ -1094,7 +1165,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1118,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1128,9 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1158,10 +1229,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
-name = "hyper"
-version = "1.10.1"
+name = "hybrid-array"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1369,7 +1449,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crossterm",
  "dyn-clone",
  "fuzzy-matcher",
@@ -1428,7 +1508,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1447,7 +1527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1472,9 +1552,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -1498,7 +1578,7 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
  "plain",
  "redox_syscall 0.9.0",
@@ -1594,7 +1674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1605,9 +1685,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mime"
@@ -1626,10 +1706,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.2.1"
+name = "miniz_oxide"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -1672,7 +1762,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
@@ -1694,11 +1784,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -1743,7 +1832,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
@@ -1911,18 +2000,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1941,9 +2030,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1952,9 +2041,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2017,7 +2106,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2026,7 +2115,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2042,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2054,9 +2143,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2128,8 +2217,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -2144,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -2155,24 +2244,25 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
 dependencies = [
+ "mime_guess",
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn",
+ "syn 2.0.119",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
- "sha2",
+ "sha2 0.11.0",
  "walkdir",
 ]
 
@@ -2191,7 +2281,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno 0.3.14",
  "libc",
  "linux-raw-sys",
@@ -2200,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "once_cell",
  "ring",
@@ -2273,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -2313,7 +2403,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2338,9 +2428,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2348,22 +2438,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -2381,9 +2471,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -2430,13 +2520,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2446,8 +2536,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2502,15 +2603,21 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
 [[package]]
-name = "simd_cesu8"
-version = "1.1.1"
+name = "simd-adler32"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -2539,9 +2646,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2606,7 +2713,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror",
  "tokio",
@@ -2626,7 +2733,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2644,12 +2751,12 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.119",
  "tokio",
  "url",
 ]
@@ -2662,12 +2769,12 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -2684,11 +2791,11 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -2705,7 +2812,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "chrono",
  "crc",
@@ -2723,10 +2830,10 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.6",
+ "rand 0.8.7",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -2801,9 +2908,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2827,7 +2945,18 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -2845,38 +2974,38 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "libc",
@@ -2896,9 +3025,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2916,9 +3045,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2931,9 +3060,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -2947,13 +3076,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2996,13 +3125,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -3029,7 +3159,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -3075,7 +3205,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3135,7 +3265,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -3154,7 +3284,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.9.5",
  "web-time",
 ]
 
@@ -3241,9 +3371,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -3350,7 +3480,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -3414,9 +3544,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3427,14 +3557,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3501,7 +3631,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3512,7 +3642,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3743,6 +3873,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3779,28 +3919,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3820,7 +3960,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -3860,11 +4000,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ sqlx = { version = "0.8.6", default-features = false, features = ["macros", "mig
 libsqlite3-sys = { version = "=0.30.1" }
 
 filetime = "0.2.29"
+flate2 = "1.1.9"
 glob = "0.3.3"
 humantime = "2.4.0"
 lazy_static = "1.5.0"
@@ -75,6 +76,7 @@ rcgen = "0.13.2"
 directories = "6.0.0"
 gethostname = "1.1.0"
 tempfile = "3.27.0"
+tar = "0.4.44"
 inquire = "0.9.4"
 chrono = { version = "0.4.45", default-features = false, features = ["std", "now", "serde"] }
 log = "0.4.33"

--- a/packaging/build-dist.sh
+++ b/packaging/build-dist.sh
@@ -114,7 +114,7 @@ cross_run() {
     fi
     dockerfile="./docker/builder/Dockerfile.cross"
     tag="private/evebox/builder:cross"
-    if [ -z "${GITHUB_REPOSITORY}" -a -t ]; then
+    if [ -z "${GITHUB_REPOSITORY}" -a -t 1 ]; then
         it="-it"
     else
         it=""

--- a/src/cli/oneshot.rs
+++ b/src/cli/oneshot.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 mod container;
+mod local;
+mod process;
 
 use crate::prelude::*;
 
@@ -12,7 +14,7 @@ use crate::server::main::build_axum_service;
 use crate::server::metrics::Metrics;
 use crate::sqlite;
 use crate::sqlite::configdb;
-use clap::{CommandFactory, FromArgMatches, Parser};
+use clap::{CommandFactory, FromArgMatches, Parser, ValueEnum};
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -30,18 +32,30 @@ struct Args {
     #[arg(hide = true, global = true, short = 'D', long, name = "data-directory")]
     data_directory: Option<String>,
 
-    /// Process INPUT as PCAP with containerized Suricata (Linux only)
+    /// Process INPUT as PCAP with Suricata
     #[arg(long)]
     pcap: bool,
 
+    /// Suricata backend: auto, local, or container
+    #[arg(long, value_name = "BACKEND", requires = "pcap", hide = cfg!(windows))]
+    suricata_backend: Option<SuricataBackend>,
+
     /// Container runtime: auto, podman, or docker (default: auto)
-    #[arg(long, value_name = "RUNTIME", requires = "pcap")]
+    #[arg(
+        long,
+        value_name = "RUNTIME",
+        requires = "pcap",
+        conflicts_with_all = ["suricata", "suricata_update"],
+        hide = cfg!(windows)
+    )]
     container_runtime: Option<container::ContainerRuntimeChoice>,
 
     #[arg(
         long,
         value_name = "IMAGE",
         requires = "pcap",
+        conflicts_with_all = ["suricata", "suricata_update"],
+        hide = cfg!(windows),
         help = format!(
             "Suricata container image (default: {})",
             container::DEFAULT_SURICATA_IMAGE
@@ -49,8 +63,27 @@ struct Args {
     )]
     suricata_image: Option<String>,
 
-    /// Process PCAP files larger than the 4 GiB limit
-    #[arg(long, requires = "pcap")]
+    /// User-installed Suricata executable (selects the local backend)
+    #[arg(
+        long,
+        value_name = "PATH",
+        requires = "pcap",
+        conflicts_with_all = ["container_runtime", "suricata_image"]
+    )]
+    suricata: Option<PathBuf>,
+
+    /// Optional suricata-update executable; direct rule downloads are used if absent
+    #[arg(
+        long,
+        value_name = "PATH",
+        requires = "pcap",
+        conflicts_with_all = ["container_runtime", "suricata_image"],
+        hide = cfg!(windows)
+    )]
+    suricata_update: Option<PathBuf>,
+
+    /// Process PCAP files larger than the container backend's 4 GiB limit
+    #[arg(long, requires = "pcap", hide = cfg!(windows))]
     force: bool,
 
     /// Limit the number of events read
@@ -65,9 +98,9 @@ struct Args {
     #[arg(long)]
     no_wait: bool,
 
-    /// Database filename
-    #[arg(long, default_value = "./oneshot.sqlite", value_name = "FILENAME")]
-    database_filename: String,
+    /// Database filename (default: oneshot.sqlite in the EveBox cache directory)
+    #[arg(long, value_name = "FILENAME")]
+    database_filename: Option<PathBuf>,
 
     /// Hostname/IP address to bind to
     #[arg(
@@ -83,8 +116,17 @@ struct Args {
     inputs: Vec<PathBuf>,
 }
 
-/// PCAPs over this size are refused without --force as a full copy is
-/// staged in the temporary directory.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
+enum SuricataBackend {
+    #[default]
+    Auto,
+    Local,
+    Container,
+}
+
+/// Container-backend PCAPs over this size are refused without --force as
+/// a full copy is staged in the temporary directory. The local backend
+/// reads PCAPs in place and has no size limit.
 const MAX_PCAP_BYTES: u64 = 4 * 1024 * 1024 * 1024;
 
 pub fn command() -> clap::Command {
@@ -104,6 +146,34 @@ struct PreparedInput {
     #[cfg(not(windows))]
     pcap_paths: Option<Vec<PathBuf>>,
     workspace: Option<TempDir>,
+}
+
+enum PreparedPcapBackend {
+    Container {
+        runtime: container::ContainerRuntime,
+        image: String,
+    },
+    Local(local::Programs),
+}
+
+impl PreparedPcapBackend {
+    fn is_container(&self) -> bool {
+        matches!(self, Self::Container { .. })
+    }
+}
+
+enum PcapEveGenerator {
+    Container(container::EveGenerator),
+    Local(Box<local::EveGenerator>),
+}
+
+impl PcapEveGenerator {
+    async fn generate(&self, pcap: &Path, output: &Path) -> Result<()> {
+        match self {
+            Self::Container(generator) => generator.generate(pcap, output).await,
+            Self::Local(generator) => generator.generate(pcap, output).await,
+        }
+    }
 }
 
 impl PreparedInput {
@@ -126,7 +196,10 @@ pub async fn main(args: &clap::ArgMatches) -> anyhow::Result<()> {
     let limit = args.limit.unwrap_or(0);
     let no_open = args.no_open;
     let no_wait = args.no_wait;
-    let db_filename = args.database_filename.clone();
+    let db_filename = match args.database_filename.clone() {
+        Some(filename) => filename,
+        None => default_database_filename()?,
+    };
     let host = args.host.clone();
     let prepared_input = prepare_input(&args).await?;
     let inputs = prepared_input.eve_inputs.clone();
@@ -134,11 +207,10 @@ pub async fn main(args: &clap::ArgMatches) -> anyhow::Result<()> {
     let pcap_paths = prepared_input.pcap_paths.clone();
     let generated_cleanup = prepared_input.cleanup_path();
 
-    info!("Using database filename {}", &db_filename);
+    info!("Using database filename {}", db_filename.display());
+    remove_stale_database(&db_filename)?;
 
-    let db_connection_builder = Arc::new(sqlite::ConnectionBuilder::filename(Some(
-        &PathBuf::from(&db_filename),
-    )));
+    let db_connection_builder = Arc::new(sqlite::ConnectionBuilder::filename(Some(&db_filename)));
     let mut conn = db_connection_builder.open_connection(true).await?;
     sqlite::connection::init_event_db(&mut conn).await?;
     let pool = sqlite::connection::open_pool(Some(&db_filename), false).await?;
@@ -306,41 +378,47 @@ async fn prepare_input(args: &Args) -> Result<PreparedInput> {
     if args.inputs.iter().any(|input| input.as_os_str() == "-") {
         anyhow::bail!("PCAP input from stdin is not supported");
     }
-    ensure_pcap_supported(std::env::consts::OS)?;
     let pcaps = args
         .inputs
         .iter()
-        .map(|input| {
-            let pcap = validate_pcap(input)?;
-            check_pcap_size(std::fs::metadata(&pcap)?.len(), args.force)?;
-            Ok(pcap)
-        })
+        .map(|input| validate_pcap(input))
         .collect::<Result<Vec<_>>>()?;
-    // Get the container runtime and image ready before staging the PCAP
-    // so we fail fast, before copying a potentially large file.
-    let choice = args.container_runtime.unwrap_or_default();
-    let image = args
-        .suricata_image
-        .as_deref()
-        .unwrap_or(container::DEFAULT_SURICATA_IMAGE);
-    let runtime = container::prepare_runtime(choice, image).await?;
-
-    let data_dir = suricata_data_dir(runtime.program())?;
-    crate::path::ensure_exists(&data_dir)
-        .with_context(|| format!("failed to create rules cache {}", data_dir.display()))?;
-    let generator = container::EveGenerator::prepare(runtime, image, &data_dir).await?;
+    // Resolve and validate all user-managed prerequisites before staging a
+    // potentially large PCAP.
+    let backend = prepare_pcap_backend(args, std::env::consts::OS).await?;
+    // Only the container backend stages a copy, so only it carries the
+    // size limit.
+    let stage_inputs = backend.is_container();
+    if stage_inputs {
+        for pcap in &pcaps {
+            check_pcap_size(std::fs::metadata(pcap)?.len(), args.force)?;
+        }
+    }
 
     let workspace = tempfile::Builder::new()
         .prefix("evebox-oneshot-pcap-")
         .tempdir()
         .context("failed to create private PCAP processing workspace")?;
-    if workspace.path().to_string_lossy().contains(',') {
+    if backend.is_container() && workspace.path().to_string_lossy().contains(',') {
         anyhow::bail!(
             "temporary directory {} contains a comma, which container mount \
              options cannot express; set TMPDIR to a path without commas",
             workspace.path().display()
         );
     }
+    let generator = match backend {
+        PreparedPcapBackend::Container { runtime, image } => {
+            let data_dir = suricata_data_dir(runtime.program())?;
+            crate::path::ensure_exists(&data_dir)
+                .with_context(|| format!("failed to create rules cache {}", data_dir.display()))?;
+            PcapEveGenerator::Container(
+                container::EveGenerator::prepare(runtime, &image, &data_dir).await?,
+            )
+        }
+        PreparedPcapBackend::Local(programs) => PcapEveGenerator::Local(Box::new(
+            local::EveGenerator::prepare(programs, workspace.path()).await?,
+        )),
+    };
     let mut eve_inputs = Vec::with_capacity(pcaps.len());
     for (index, pcap) in pcaps.iter().enumerate() {
         info!(
@@ -356,16 +434,21 @@ async fn prepare_input(args: &Args) -> Result<PreparedInput> {
                 input_workspace.display()
             )
         })?;
-        let staged_pcap = stage_pcap(pcap, &input_workspace)?;
         let eve_path = input_workspace.join("eve.json");
-
-        generator.generate(&staged_pcap, &eve_path).await?;
-        if let Err(err) = std::fs::remove_file(&staged_pcap) {
-            warn!(
-                "Failed to remove staged PCAP {}: {}",
-                staged_pcap.display(),
-                err
-            );
+        if stage_inputs {
+            // A staged copy keeps the user's original capture out of the
+            // container mounts.
+            let staged_pcap = stage_pcap(pcap, &input_workspace)?;
+            generator.generate(&staged_pcap, &eve_path).await?;
+            if let Err(err) = std::fs::remove_file(&staged_pcap) {
+                warn!(
+                    "Failed to remove staged PCAP {}: {}",
+                    staged_pcap.display(),
+                    err
+                );
+            }
+        } else {
+            generator.generate(pcap, &eve_path).await?;
         }
         eve_inputs.push(EveInput::File(eve_path));
     }
@@ -374,6 +457,91 @@ async fn prepare_input(args: &Args) -> Result<PreparedInput> {
         #[cfg(not(windows))]
         pcap_paths: Some(pcaps),
         workspace: Some(workspace),
+    })
+}
+
+async fn prepare_pcap_backend(args: &Args, platform: &str) -> Result<PreparedPcapBackend> {
+    match selected_backend(args, platform)? {
+        SuricataBackend::Local => prepare_local_backend(args).await,
+        SuricataBackend::Container if allows_local_fallback(args) => {
+            match container::resolve_runtime(args.container_runtime.unwrap_or_default()).await {
+                Ok(runtime) => prepare_container_backend_with_runtime(args, runtime).await,
+                Err(runtime_error) => {
+                    warn!(
+                        "No usable container runtime was found: {runtime_error:#}; trying local Suricata"
+                    );
+                    prepare_local_backend(args).await.with_context(|| {
+                        format!(
+                            "no usable container runtime was found ({runtime_error:#}) and \
+                             the local Suricata backend could not be prepared"
+                        )
+                    })
+                }
+            }
+        }
+        SuricataBackend::Container => prepare_container_backend(args, platform).await,
+        SuricataBackend::Auto => unreachable!("auto backend must be resolved before preparation"),
+    }
+}
+
+fn allows_local_fallback(args: &Args) -> bool {
+    args.suricata_backend.unwrap_or_default() == SuricataBackend::Auto
+        && args.container_runtime.is_none()
+        && args.suricata_image.is_none()
+}
+
+fn selected_backend(args: &Args, platform: &str) -> Result<SuricataBackend> {
+    let requested = args.suricata_backend.unwrap_or_default();
+    let has_local_options = args.suricata.is_some() || args.suricata_update.is_some();
+    let has_container_options = args.container_runtime.is_some() || args.suricata_image.is_some();
+
+    if requested == SuricataBackend::Local && has_container_options {
+        anyhow::bail!(
+            "--suricata-backend local cannot be combined with container runtime or image options"
+        );
+    }
+    if requested == SuricataBackend::Container && has_local_options {
+        anyhow::bail!(
+            "--suricata-backend container cannot be combined with local executable options"
+        );
+    }
+
+    Ok(match requested {
+        SuricataBackend::Auto if has_local_options => SuricataBackend::Local,
+        SuricataBackend::Auto if has_container_options => SuricataBackend::Container,
+        SuricataBackend::Auto if platform != "linux" => SuricataBackend::Local,
+        SuricataBackend::Auto => SuricataBackend::Container,
+        other => other,
+    })
+}
+
+async fn prepare_local_backend(args: &Args) -> Result<PreparedPcapBackend> {
+    let programs =
+        local::Programs::discover(args.suricata.as_deref(), args.suricata_update.as_deref())
+            .await?;
+    Ok(PreparedPcapBackend::Local(programs))
+}
+
+async fn prepare_container_backend(args: &Args, platform: &str) -> Result<PreparedPcapBackend> {
+    if platform != "linux" {
+        anyhow::bail!("the container Suricata backend is currently supported on Linux only");
+    }
+    let runtime = container::resolve_runtime(args.container_runtime.unwrap_or_default()).await?;
+    prepare_container_backend_with_runtime(args, runtime).await
+}
+
+async fn prepare_container_backend_with_runtime(
+    args: &Args,
+    runtime: container::ContainerRuntime,
+) -> Result<PreparedPcapBackend> {
+    let image = args
+        .suricata_image
+        .as_deref()
+        .unwrap_or(container::DEFAULT_SURICATA_IMAGE);
+    container::prepare_runtime(runtime, image).await?;
+    Ok(PreparedPcapBackend::Container {
+        runtime,
+        image: image.to_string(),
     })
 }
 
@@ -455,13 +623,6 @@ fn check_pcap_size(size: u64, force: bool) -> Result<()> {
     Ok(())
 }
 
-fn ensure_pcap_supported(platform: &str) -> Result<()> {
-    if platform != "linux" {
-        anyhow::bail!("oneshot PCAP processing is currently supported on Linux only");
-    }
-    Ok(())
-}
-
 fn validate_pcap(path: &Path) -> Result<PathBuf> {
     let metadata = std::fs::metadata(path)
         .with_context(|| format!("failed to access PCAP input {}", path.display()))?;
@@ -484,14 +645,63 @@ fn validate_pcap(path: &Path) -> Result<PathBuf> {
         anyhow::bail!("input is not an uncompressed PCAP file: {}", path.display());
     }
 
-    path.canonicalize()
-        .with_context(|| format!("failed to resolve PCAP input {}", path.display()))
+    // On Windows canonicalize returns \\?\-prefixed extended-length
+    // paths, which Suricata is not expected to handle when reading the
+    // PCAP in place, so settle for an absolute path there.
+    #[cfg(windows)]
+    let resolved = std::path::absolute(path);
+    #[cfg(not(windows))]
+    let resolved = path.canonicalize();
+    resolved.with_context(|| format!("failed to resolve PCAP input {}", path.display()))
 }
 
-fn cleanup_database(filename: &str) {
-    let _ = std::fs::remove_file(filename);
-    let _ = std::fs::remove_file(format!("{}-shm", filename));
-    let _ = std::fs::remove_file(format!("{}-wal", filename));
+/// The default database lives in the EveBox cache directory rather than
+/// the current directory so any leftovers never land in a user's working
+/// directory.
+fn default_database_filename() -> Result<PathBuf> {
+    let dirs = directories::ProjectDirs::from("org", "evebox", "evebox")
+        .context("failed to determine a cache directory for the oneshot database")?;
+    let cache_dir = dirs.cache_dir();
+    crate::path::ensure_exists(cache_dir)
+        .with_context(|| format!("failed to create cache directory {}", cache_dir.display()))?;
+    Ok(cache_dir.join("oneshot.sqlite"))
+}
+
+/// Remove database files left over from a previous run: Windows cannot
+/// remove them at exit while SQLite still holds them open, and importing
+/// into a leftover database would mix in the previous run's events.
+fn remove_stale_database(filename: &Path) -> Result<()> {
+    for path in database_files(filename) {
+        match std::fs::remove_file(&path) {
+            Ok(()) => info!("Removed stale database file {}", path.display()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!(
+                        "failed to remove stale database file {}, is another \
+                         oneshot instance running?",
+                        path.display()
+                    )
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn database_files(filename: &Path) -> [PathBuf; 3] {
+    let suffixed = |suffix: &str| {
+        let mut path = filename.as_os_str().to_owned();
+        path.push(suffix);
+        PathBuf::from(path)
+    };
+    [filename.to_path_buf(), suffixed("-shm"), suffixed("-wal")]
+}
+
+fn cleanup_database(filename: &Path) {
+    for path in database_files(filename) {
+        let _ = std::fs::remove_file(path);
+    }
 }
 
 fn cleanup_generated(path: &Option<PathBuf>) {
@@ -680,7 +890,7 @@ mod tests {
     }
 
     #[test]
-    fn container_options_require_pcap_mode() {
+    fn pcap_backend_options_require_pcap_mode() {
         for option in [
             ["oneshot", "--container-runtime", "docker", "eve.json"],
             [
@@ -689,6 +899,14 @@ mod tests {
                 "example/suricata",
                 "eve.json",
             ],
+            ["oneshot", "--suricata", "/usr/bin/suricata", "eve.json"],
+            [
+                "oneshot",
+                "--suricata-update",
+                "/usr/bin/suricata-update",
+                "eve.json",
+            ],
+            ["oneshot", "--suricata-backend", "local", "eve.json"],
         ] {
             let err = Args::try_parse_from(option).unwrap_err();
             assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
@@ -725,19 +943,19 @@ mod tests {
     }
 
     #[test]
-    fn pcap_mode_rejects_non_linux_platforms() {
-        let err = ensure_pcap_supported("windows").unwrap_err();
-        assert!(err.to_string().contains("Linux only"));
-    }
-
-    #[test]
     fn validates_pcap_magic() {
         for magic in [[0xd4, 0xc3, 0xb2, 0xa1], [0xa1, 0xb2, 0xc3, 0xd4]] {
             let dir = tempfile::tempdir().unwrap();
             let path = dir.path().join("capture file");
             let mut file = File::create(&path).unwrap();
             file.write_all(&magic).unwrap();
-            assert_eq!(validate_pcap(&path).unwrap(), path.canonicalize().unwrap());
+            // Windows resolves to an absolute path without the \\?\
+            // prefix canonicalize would add.
+            #[cfg(windows)]
+            let expected = std::path::absolute(&path).unwrap();
+            #[cfg(not(windows))]
+            let expected = path.canonicalize().unwrap();
+            assert_eq!(validate_pcap(&path).unwrap(), expected);
         }
     }
 

--- a/src/cli/oneshot/container.rs
+++ b/src/cli/oneshot/container.rs
@@ -3,11 +3,17 @@
 
 use crate::prelude::*;
 
+#[cfg(test)]
+use super::process::CommandResult;
+use super::process::{
+    CommandSpec, ExecuteError, ExecutionMode, ProcessExecutor, TokioProcessExecutor,
+    validate_eve_output,
+};
+
 use clap::ValueEnum;
 use std::ffi::OsString;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
 use uuid::Uuid;
 
 pub(super) const DEFAULT_SURICATA_IMAGE: &str = "docker.io/jasonish/suricata:8.0";
@@ -44,132 +50,26 @@ impl ContainerRuntime {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct CommandSpec {
-    program: OsString,
-    args: Vec<OsString>,
-}
-
 impl CommandSpec {
-    fn new(
-        program: impl Into<OsString>,
-        args: impl IntoIterator<Item = impl Into<OsString>>,
-    ) -> Self {
-        Self {
-            program: program.into(),
-            args: args.into_iter().map(Into::into).collect(),
-        }
-    }
-
     fn runtime(
         runtime: ContainerRuntime,
         args: impl IntoIterator<Item = impl Into<OsString>>,
     ) -> Self {
         Self::new(runtime.program(), args)
     }
-
-    fn display(&self) -> String {
-        std::iter::once(&self.program)
-            .chain(self.args.iter())
-            .map(|arg| arg.to_string_lossy())
-            .collect::<Vec<_>>()
-            .join(" ")
-    }
 }
 
-#[derive(Clone, Copy, Debug)]
-enum ExecutionMode {
-    /// Capture output, keeping podman/docker chatter such as created and
-    /// removed resource names out of the user's terminal.
-    Capture,
-    /// Show live output, for the containers doing real, visible work.
-    Interruptible,
-}
-
-#[derive(Debug)]
-struct CommandResult {
-    success: bool,
-    code: Option<i32>,
-    stdout: String,
-    stderr: String,
-}
-
-#[derive(Debug, thiserror::Error)]
-enum ExecuteError {
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
-    #[error("interrupted")]
-    Interrupted,
-}
-
-#[async_trait::async_trait]
-trait ProcessExecutor: Send + Sync {
-    async fn execute(
-        &self,
-        command: &CommandSpec,
-        mode: ExecutionMode,
-    ) -> Result<CommandResult, ExecuteError>;
-}
-
-struct TokioProcessExecutor;
-
-#[async_trait::async_trait]
-impl ProcessExecutor for TokioProcessExecutor {
-    async fn execute(
-        &self,
-        command: &CommandSpec,
-        mode: ExecutionMode,
-    ) -> Result<CommandResult, ExecuteError> {
-        let mut process = tokio::process::Command::new(&command.program);
-        process.args(&command.args).stdin(Stdio::null());
-
-        if matches!(mode, ExecutionMode::Capture) {
-            process.kill_on_drop(true);
-            let output = tokio::select! {
-                output = process.output() => output?,
-                signal = tokio::signal::ctrl_c() => {
-                    signal?;
-                    return Err(ExecuteError::Interrupted);
-                }
-            };
-            return Ok(CommandResult {
-                success: output.status.success(),
-                code: output.status.code(),
-                stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-            });
-        }
-
-        process.stdout(Stdio::inherit()).stderr(Stdio::inherit());
-        let mut child = process.kill_on_drop(true).spawn()?;
-        let status = tokio::select! {
-            status = child.wait() => status?,
-            signal = tokio::signal::ctrl_c() => {
-                signal?;
-                let _ = child.kill().await;
-                return Err(ExecuteError::Interrupted);
-            }
-        };
-
-        Ok(CommandResult {
-            success: status.success(),
-            code: status.code(),
-            stdout: String::new(),
-            stderr: String::new(),
-        })
-    }
-}
-
-/// Resolve the container runtime and make sure the Suricata image is
-/// present and current, before any real processing starts.
-pub(super) async fn prepare_runtime(
-    choice: ContainerRuntimeChoice,
-    image: &str,
-) -> Result<ContainerRuntime> {
-    let executor = TokioProcessExecutor;
-    let runtime = resolve_runtime(choice, &executor).await?;
-    ensure_image_is_current(&executor, runtime, image, &TerminalImageUpdatePrompt).await?;
-    Ok(runtime)
+/// Make sure the Suricata image is present and current before any real
+/// processing starts.
+pub(super) async fn prepare_runtime(runtime: ContainerRuntime, image: &str) -> Result<()> {
+    ensure_image_is_current(
+        &TokioProcessExecutor,
+        runtime,
+        image,
+        &TerminalImageUpdatePrompt,
+    )
+    .await?;
+    Ok(())
 }
 
 pub(super) struct EveGenerator {
@@ -403,7 +303,11 @@ fn parse_suricata_version(output: &str) -> Result<semver::Version> {
         .context("Suricata version output did not contain a semantic version")
 }
 
-async fn resolve_runtime(
+pub(super) async fn resolve_runtime(choice: ContainerRuntimeChoice) -> Result<ContainerRuntime> {
+    resolve_runtime_with_executor(choice, &TokioProcessExecutor).await
+}
+
+async fn resolve_runtime_with_executor(
     choice: ContainerRuntimeChoice,
     executor: &dyn ProcessExecutor,
 ) -> Result<ContainerRuntime> {
@@ -674,7 +578,6 @@ impl<'a> ContainerJob<'a> {
             OsString::from("none"),
             OsString::from("-l"),
             OsString::from("/var/log/suricata"),
-            OsString::from("--init-errors-fatal"),
         ]);
         self.run_checked(
             "running Suricata against the PCAP",
@@ -717,7 +620,7 @@ impl<'a> ContainerJob<'a> {
             "chmod -R a+rX /var/lib/suricata",
         );
         info!(
-            "Updating ET/Open, PawPatRules, and The Hunters Ledger rules with {}",
+            "Updating ET/Open, PAW Patrules, and The Hunters Ledger rules with {}",
             self.runtime.name()
         );
         self.update_active = true;
@@ -832,28 +735,6 @@ async fn generate_eve_with(
     job.cleanup().await;
     result?;
     validate_eve_output(output)
-}
-
-fn validate_eve_output(output: &Path) -> Result<()> {
-    let metadata = std::fs::metadata(output).with_context(|| {
-        format!(
-            "Suricata completed but did not produce a readable eve.json at {}",
-            output.display()
-        )
-    })?;
-    if !metadata.is_file() {
-        anyhow::bail!(
-            "Suricata output is not a regular eve.json file: {}",
-            output.display()
-        );
-    }
-    std::fs::File::open(output).with_context(|| {
-        format!(
-            "Suricata produced an unreadable eve.json at {}",
-            output.display()
-        )
-    })?;
-    Ok(())
 }
 
 #[cfg(test)]
@@ -1393,7 +1274,6 @@ mod tests {
             "none".to_string(),
             "-l".to_string(),
             "/var/log/suricata".to_string(),
-            "--init-errors-fatal".to_string(),
         ]));
 
         assert_eq!(
@@ -1665,7 +1545,7 @@ mod tests {
             ContainerRuntimeChoice::Podman,
             ContainerRuntimeChoice::Docker,
         ] {
-            let Ok(runtime) = resolve_runtime(choice, &executor).await else {
+            let Ok(runtime) = resolve_runtime_with_executor(choice, &executor).await else {
                 continue;
             };
             let tempdir = tempfile::tempdir().unwrap();

--- a/src/cli/oneshot/local/mod.rs
+++ b/src/cli/oneshot/local/mod.rs
@@ -1,0 +1,679 @@
+// SPDX-FileCopyrightText: (C) 2026 Jason Ish <jason@codemonkey.net>
+// SPDX-License-Identifier: MIT
+
+use crate::prelude::*;
+
+mod rules;
+
+use super::process::{
+    CommandResult, CommandSpec, ExecuteError, ExecutionMode, ProcessExecutor, TokioProcessExecutor,
+    path, validate_eve_output,
+};
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+
+const MINIMUM_SURICATA_VERSION: &str = "8.0.0";
+const RULE_SOURCES: [&str; 3] = ["et/open", "pawpatrules", "the-hunters-ledger/open"];
+const REFERENCE_CONFIG: &str = r#"# EveBox oneshot reference configuration.
+config reference: cve https://cve.mitre.org/cgi-bin/cvename.cgi?name=
+config reference: nessus https://www.tenable.com/plugins/nessus/
+config reference: url https://
+config reference: mcafee https://vil.nai.com/vil/content/v_
+config reference: bid https://www.securityfocus.com/bid/
+config reference: bugtraq https://www.securityfocus.com/bid/
+config reference: md5 https://www.threatexpert.com/report.aspx?md5=
+config reference: secunia https://www.secunia.com/advisories/
+config reference: arachnids https://www.whitehats.com/info/IDS
+config reference: exploitdb https://www.exploit-db.com/exploits/
+config reference: msft https://technet.microsoft.com/security/bulletin/
+config reference: et https://doc.emergingthreats.net/
+config reference: etpro https://doc.emergingthreatspro.com/
+config reference: telus https://
+config reference: xforce http://xforce.iss.net/xforce/xfdb/
+config reference: osvdb http://osvdb.org/show/osvdb/
+config reference: threatexpert http://www.threatexpert.com/report.aspx?md5=
+config reference: openpacket https://www.openpacket.org/capture/grab/
+config reference: securitytracker http://securitytracker.com/id?
+"#;
+
+#[derive(Clone, Debug)]
+pub(super) struct Programs {
+    suricata: PathBuf,
+    suricata_update: Option<PathBuf>,
+    version: semver::Version,
+}
+
+impl Programs {
+    pub(super) async fn discover(
+        suricata: Option<&Path>,
+        suricata_update: Option<&Path>,
+    ) -> Result<Self> {
+        Self::discover_with(
+            suricata,
+            suricata_update,
+            &SearchEnvironment::current(),
+            &TokioProcessExecutor,
+        )
+        .await
+    }
+
+    async fn discover_with(
+        suricata: Option<&Path>,
+        suricata_update: Option<&Path>,
+        environment: &SearchEnvironment,
+        executor: &dyn ProcessExecutor,
+    ) -> Result<Self> {
+        let suricata = resolve_executable(suricata, "suricata", environment, "--suricata")?;
+        let suricata_update = match suricata_update {
+            Some(requested) => Some(resolve_executable(
+                Some(requested),
+                "suricata-update",
+                environment,
+                "--suricata-update",
+            )?),
+            None => {
+                resolve_executable(None, "suricata-update", environment, "--suricata-update").ok()
+            }
+        };
+
+        let version = inspect_suricata_version(executor, &suricata).await?;
+        let minimum = semver::Version::parse(MINIMUM_SURICATA_VERSION)?;
+        if version < minimum {
+            anyhow::bail!(
+                "local Suricata {} at {} is older than the supported minimum {}; use \
+                 --suricata to select a compatible executable",
+                version,
+                suricata.display(),
+                minimum
+            );
+        }
+
+        info!("Using local Suricata {} at {}", version, suricata.display());
+        if let Some(updater) = &suricata_update {
+            debug!("Using suricata-update at {}", updater.display());
+        } else {
+            info!("suricata-update was not found; rules will be downloaded directly");
+        }
+        Ok(Self {
+            suricata,
+            suricata_update,
+            version,
+        })
+    }
+}
+
+struct SearchEnvironment {
+    platform: &'static str,
+    path: Option<OsString>,
+    program_files: Option<PathBuf>,
+}
+
+impl SearchEnvironment {
+    fn current() -> Self {
+        Self {
+            platform: std::env::consts::OS,
+            path: std::env::var_os("PATH"),
+            program_files: std::env::var_os("ProgramFiles").map(PathBuf::from),
+        }
+    }
+}
+
+fn resolve_executable(
+    requested: Option<&Path>,
+    program: &str,
+    environment: &SearchEnvironment,
+    override_flag: &str,
+) -> Result<PathBuf> {
+    if let Some(requested) = requested
+        && (requested.is_absolute() || requested.components().count() > 1)
+    {
+        return checked_executable(requested).with_context(|| {
+            format!(
+                "the executable selected by {override_flag} is not usable: {}",
+                requested.display()
+            )
+        });
+    }
+
+    let requested_name = requested
+        .and_then(Path::file_name)
+        .unwrap_or_else(|| OsStr::new(program));
+    let names = executable_names(requested_name, environment.platform);
+    if let Some(search_path) = &environment.path {
+        for directory in std::env::split_paths(search_path) {
+            for name in &names {
+                let candidate = directory.join(name);
+                if let Ok(path) = checked_executable(&candidate) {
+                    return Ok(path);
+                }
+            }
+        }
+    }
+
+    if environment.platform == "windows"
+        && let Some(program_files) = &environment.program_files
+    {
+        for name in &names {
+            let candidate = program_files.join("Suricata").join(name);
+            if let Ok(path) = checked_executable(&candidate) {
+                return Ok(path);
+            }
+        }
+    }
+
+    anyhow::bail!(
+        "could not find {program} in the supported search locations; use {override_flag} PATH \
+         to select it"
+    )
+}
+
+fn executable_names(name: &OsStr, platform: &str) -> Vec<OsString> {
+    if platform != "windows" || Path::new(name).extension().is_some() {
+        return vec![name.to_os_string()];
+    }
+    let mut with_exe = name.to_os_string();
+    with_exe.push(".exe");
+    vec![with_exe, name.to_os_string()]
+}
+
+fn checked_executable(path: &Path) -> Result<PathBuf> {
+    if !std::fs::metadata(path).is_ok_and(|metadata| metadata.is_file()) {
+        anyhow::bail!("{} is not a regular file", path.display());
+    }
+    path.canonicalize()
+        .with_context(|| format!("failed to resolve executable {}", path.display()))
+}
+
+async fn inspect_suricata_version(
+    executor: &dyn ProcessExecutor,
+    suricata: &Path,
+) -> Result<semver::Version> {
+    let command = CommandSpec::new(path(suricata), [OsString::from("-V")]);
+    let result = executor
+        .execute(&command, ExecutionMode::Capture)
+        .await
+        .with_context(|| format!("failed to run local Suricata at {}", suricata.display()))?;
+    if !result.success {
+        return failed_command("checking the local Suricata version", &command, result);
+    }
+    parse_suricata_version(&format!("{} {}", result.stdout, result.stderr)).with_context(|| {
+        format!(
+            "failed to determine the version of local Suricata at {}",
+            suricata.display()
+        )
+    })
+}
+
+fn parse_suricata_version(output: &str) -> Result<semver::Version> {
+    output
+        .split_whitespace()
+        .find_map(|word| semver::Version::parse(word).ok())
+        .context("Suricata version output did not contain a semantic version")
+}
+
+#[derive(Clone, Debug)]
+struct WorkspaceLayout {
+    suricata_config: PathBuf,
+    reference_config: PathBuf,
+    threshold_config: PathBuf,
+    classification_config: PathBuf,
+    updater_config: PathBuf,
+    updater_data: PathBuf,
+    updater_cache: PathBuf,
+    disable_config: PathBuf,
+    enable_config: PathBuf,
+    drop_config: PathBuf,
+    modify_config: PathBuf,
+    rules: PathBuf,
+    rule_file: PathBuf,
+    default_log: PathBuf,
+}
+
+impl WorkspaceLayout {
+    fn create(root: &Path, persistent_updater_cache: Option<PathBuf>) -> Result<Self> {
+        let config = root.join("config");
+        let updater = root.join("updater");
+        let rules = root.join("rules");
+        let updater_cache = persistent_updater_cache.unwrap_or_else(|| updater.join("cache"));
+        let layout = Self {
+            suricata_config: config.join("suricata.yaml"),
+            reference_config: rules.join("reference.config"),
+            threshold_config: config.join("threshold.config"),
+            classification_config: rules.join("classification.config"),
+            updater_config: updater.join("update.yaml"),
+            updater_data: updater.join("data"),
+            updater_cache,
+            disable_config: updater.join("disable.conf"),
+            enable_config: updater.join("enable.conf"),
+            drop_config: updater.join("drop.conf"),
+            modify_config: updater.join("modify.conf"),
+            rule_file: rules.join("suricata.rules"),
+            rules,
+            default_log: root.join("log"),
+        };
+
+        for directory in [
+            &config,
+            &updater,
+            &layout.rules,
+            &layout.updater_data,
+            &layout.updater_cache,
+            &layout.default_log,
+        ] {
+            std::fs::create_dir_all(directory).with_context(|| {
+                format!(
+                    "failed to create local Suricata directory {}",
+                    directory.display()
+                )
+            })?;
+        }
+        layout.write_files()?;
+        Ok(layout)
+    }
+
+    fn write_files(&self) -> Result<()> {
+        let suricata_config = serde_json::json!({
+            "vars": {
+                "address-groups": {
+                    "HOME_NET": "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]",
+                    "EXTERNAL_NET": "!$HOME_NET",
+                    "HTTP_SERVERS": "$HOME_NET",
+                    "SMTP_SERVERS": "$HOME_NET",
+                    "SQL_SERVERS": "$HOME_NET",
+                    "DNS_SERVERS": "$HOME_NET",
+                    "TELNET_SERVERS": "$HOME_NET",
+                    "AIM_SERVERS": "$EXTERNAL_NET",
+                    "DC_SERVERS": "$HOME_NET",
+                    "DNP3_SERVER": "$HOME_NET",
+                    "DNP3_CLIENT": "$HOME_NET",
+                    "MODBUS_CLIENT": "$HOME_NET",
+                    "MODBUS_SERVER": "$HOME_NET",
+                    "ENIP_CLIENT": "$HOME_NET",
+                    "ENIP_SERVER": "$HOME_NET"
+                },
+                "port-groups": {
+                    "HTTP_PORTS": "80",
+                    "SHELLCODE_PORTS": "!80",
+                    "ORACLE_PORTS": 1521,
+                    "SSH_PORTS": 22,
+                    "DNP3_PORTS": 20000,
+                    "MODBUS_PORTS": 502,
+                    "FILE_DATA_PORTS": "[$HTTP_PORTS,110,143]",
+                    "FTP_PORTS": 21,
+                    "GENEVE_PORTS": 6081,
+                    "VXLAN_PORTS": 4789,
+                    "TEREDO_PORTS": 3544,
+                    "SIP_PORTS": "[5060, 5061]"
+                }
+            },
+            "default-log-dir": utf8_path(&self.default_log)?,
+            "default-rule-path": utf8_path(&self.rules)?,
+            "classification-file": utf8_path(&self.classification_config)?,
+            "reference-config-file": utf8_path(&self.reference_config)?,
+            "threshold-file": utf8_path(&self.threshold_config)?,
+            "rule-files": [],
+            // The DNP3 and Modbus parsers are disabled by default and must
+            // be enabled for their loggers to produce events, while the
+            // BitTorrent DHT and PostgreSQL loggers are only registered
+            // when their app-layer nodes are present. Everything else is
+            // left to the built-in defaults.
+            "app-layer": {
+                "protocols": {
+                    "bittorrent-dht": {"enabled": true},
+                    "dnp3": {"enabled": true},
+                    "modbus": {"enabled": true},
+                    "pgsql": {"enabled": true}
+                }
+            },
+            "outputs": [{
+                "eve-log": {
+                    "enabled": true,
+                    "filetype": "regular",
+                    "filename": "eve.json",
+                    // All protocol loggers, including those disabled in the
+                    // default Suricata configuration, with extended logging
+                    // where the logger supports it.
+                    "types": [
+                        "alert",
+                        "anomaly",
+                        {"http": {"extended": true}},
+                        "dns",
+                        "mdns",
+                        {"tls": {"extended": true}},
+                        {"files": {"force-hash": ["md5", "sha256"]}},
+                        {"smtp": {"extended": true}},
+                        "websocket",
+                        "ftp",
+                        "rdp",
+                        "nfs",
+                        "smb",
+                        "tftp",
+                        {"ike": {"extended": true}},
+                        "dcerpc",
+                        "krb5",
+                        "bittorrent-dht",
+                        "snmp",
+                        "rfb",
+                        "sip",
+                        "dnp3",
+                        "enip",
+                        "modbus",
+                        "quic",
+                        "ldap",
+                        "pop3",
+                        "arp",
+                        {"dhcp": {"extended": true}},
+                        "ssh",
+                        "mqtt",
+                        "http2",
+                        "doh2",
+                        "pgsql",
+                        "stats",
+                        "flow"
+                    ]
+                }
+            }],
+            "logging": {
+                "default-log-level": "notice",
+                "outputs": [{"console": {"enabled": true}}]
+            }
+        });
+        let yaml = serde_yaml::to_string(&suricata_config)
+            .context("failed to generate the local Suricata configuration")?;
+        std::fs::write(&self.suricata_config, format!("%YAML 1.1\n---\n{yaml}")).with_context(
+            || {
+                format!(
+                    "failed to write local Suricata configuration {}",
+                    self.suricata_config.display()
+                )
+            },
+        )?;
+
+        let updater_config = serde_json::json!({
+            "cache-directory": utf8_path(&self.updater_cache)?,
+            "sources": []
+        });
+        std::fs::write(
+            &self.updater_config,
+            serde_yaml::to_string(&updater_config)
+                .context("failed to generate the isolated suricata-update configuration")?,
+        )?;
+
+        std::fs::write(&self.reference_config, REFERENCE_CONFIG).with_context(|| {
+            format!(
+                "failed to write local Suricata reference configuration {}",
+                self.reference_config.display()
+            )
+        })?;
+        for (path, description) in [
+            (&self.threshold_config, "threshold"),
+            (&self.classification_config, "classification"),
+            (&self.enable_config, "enable filter"),
+            (&self.drop_config, "drop filter"),
+            (&self.modify_config, "modify filter"),
+        ] {
+            std::fs::write(
+                path,
+                format!("# EveBox oneshot {description} configuration.\n"),
+            )
+            .with_context(|| format!("failed to write {}", path.display()))?;
+        }
+
+        let mut disable_filter = String::from("# EveBox oneshot disable filter configuration.\n");
+        if cfg!(windows) {
+            // The Windows Suricata builds do not include libmagic, so rules
+            // using the file.magic or filemagic keywords fail to load there.
+            disable_filter.push_str("re:file\\.magic\nre:filemagic\n");
+        }
+        std::fs::write(&self.disable_config, disable_filter)
+            .with_context(|| format!("failed to write {}", self.disable_config.display()))?;
+        Ok(())
+    }
+}
+
+fn utf8_path(path: &Path) -> Result<&str> {
+    path.to_str().with_context(|| {
+        format!(
+            "local Suricata workspace path is not valid Unicode: {}",
+            path.display()
+        )
+    })
+}
+
+pub(super) struct EveGenerator {
+    programs: Programs,
+    layout: WorkspaceLayout,
+}
+
+impl EveGenerator {
+    pub(super) async fn prepare(programs: Programs, workspace: &Path) -> Result<Self> {
+        Self::prepare_with(programs, workspace, &TokioProcessExecutor).await
+    }
+
+    async fn prepare_with(
+        programs: Programs,
+        workspace: &Path,
+        executor: &dyn ProcessExecutor,
+    ) -> Result<Self> {
+        let updater_cache = if programs.suricata_update.is_some() {
+            match updater_cache_directory().and_then(|path| {
+                std::fs::create_dir_all(&path).with_context(|| {
+                    format!(
+                        "failed to create persistent suricata-update cache {}",
+                        path.display()
+                    )
+                })?;
+                Ok(path)
+            }) {
+                Ok(path) => Some(path),
+                Err(err) => {
+                    warn!(
+                        "Persistent suricata-update cache is unavailable; using the temporary \
+                         workspace cache: {err:#}"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        let generator = Self {
+            programs,
+            layout: WorkspaceLayout::create(workspace, updater_cache)?,
+        };
+        generator.update_rules(executor).await?;
+        Ok(generator)
+    }
+
+    pub(super) async fn generate(&self, pcap: &Path, output: &Path) -> Result<()> {
+        self.generate_with(&TokioProcessExecutor, pcap, output)
+            .await
+    }
+
+    async fn generate_with(
+        &self,
+        executor: &dyn ProcessExecutor,
+        pcap: &Path,
+        output: &Path,
+    ) -> Result<()> {
+        let output_directory = output
+            .parent()
+            .context("local Suricata output path has no parent directory")?;
+        let command = self.replay_command(pcap, output_directory);
+        info!(
+            "Processing {} with local Suricata {}",
+            pcap.display(),
+            self.programs.version
+        );
+        execute_checked(
+            executor,
+            "running local Suricata against the PCAP",
+            command,
+            ExecutionMode::Interruptible,
+        )
+        .await?;
+        validate_eve_output(output)
+    }
+
+    async fn update_rules(&self, executor: &dyn ProcessExecutor) -> Result<()> {
+        if self.programs.suricata_update.is_none() {
+            info!("Downloading ET/Open, PAW Patrules, and The Hunters Ledger rules directly");
+            let summary = rules::download_and_merge(
+                &self.programs.version,
+                &self.layout.rules,
+                &self.layout.rule_file,
+            )
+            .await?;
+            info!(
+                "Merged {} rule files while preserving {} archive files in {}",
+                summary.rule_files,
+                summary.archive_files,
+                self.layout.rules.display()
+            );
+            return Ok(());
+        }
+
+        info!("Updating ET/Open, PAW Patrules, and The Hunters Ledger rules locally");
+        execute_checked(
+            executor,
+            "updating the Suricata rule source index",
+            self.source_command("update-sources", None),
+            ExecutionMode::Interruptible,
+        )
+        .await?;
+        for source in RULE_SOURCES {
+            execute_checked(
+                executor,
+                &format!("enabling Suricata rule source {source}"),
+                self.source_command("enable-source", Some(source)),
+                ExecutionMode::Interruptible,
+            )
+            .await?;
+        }
+        execute_checked(
+            executor,
+            "downloading and preparing local Suricata rules",
+            self.update_command(),
+            ExecutionMode::Interruptible,
+        )
+        .await
+    }
+
+    fn updater_base_args(&self, subcommand: &str) -> Vec<OsString> {
+        vec![
+            OsString::from(subcommand),
+            OsString::from("--data-dir"),
+            path(&self.layout.updater_data),
+            OsString::from("--config"),
+            path(&self.layout.updater_config),
+            OsString::from("--suricata"),
+            path(&self.programs.suricata),
+            OsString::from("--suricata-conf"),
+            path(&self.layout.suricata_config),
+        ]
+    }
+
+    fn source_command(&self, subcommand: &str, source: Option<&str>) -> CommandSpec {
+        let mut args = self.updater_base_args(subcommand);
+        if let Some(source) = source {
+            args.push(OsString::from(source));
+        }
+        CommandSpec::new(path(self.suricata_update()), args)
+    }
+
+    fn update_command(&self) -> CommandSpec {
+        let mut args = self.updater_base_args("update");
+        for (option, value) in [
+            ("--output", &self.layout.rules),
+            ("--disable-conf", &self.layout.disable_config),
+            ("--enable-conf", &self.layout.enable_config),
+            ("--drop-conf", &self.layout.drop_config),
+            ("--modify-conf", &self.layout.modify_config),
+        ] {
+            args.push(OsString::from(option));
+            args.push(path(value));
+        }
+        args.extend([
+            OsString::from("--no-test"),
+            OsString::from("--no-reload"),
+            OsString::from("--fail"),
+        ]);
+        CommandSpec::new(path(self.suricata_update()), args)
+    }
+
+    fn suricata_update(&self) -> &Path {
+        self.programs
+            .suricata_update
+            .as_deref()
+            .expect("updater command requested without suricata-update")
+    }
+
+    fn replay_command(&self, pcap: &Path, output_directory: &Path) -> CommandSpec {
+        CommandSpec::new(
+            path(&self.programs.suricata),
+            [
+                OsString::from("--runmode"),
+                OsString::from("single"),
+                OsString::from("-c"),
+                path(&self.layout.suricata_config),
+                OsString::from("-r"),
+                path(pcap),
+                OsString::from("-S"),
+                path(&self.layout.rule_file),
+                OsString::from("-k"),
+                OsString::from("none"),
+                OsString::from("-l"),
+                path(output_directory),
+            ],
+        )
+        .with_current_dir(&self.layout.rules)
+    }
+}
+
+/// Persistent suricata-update cache so repeated runs do not re-download
+/// unchanged rule feeds.
+fn updater_cache_directory() -> Result<PathBuf> {
+    let directories = directories::ProjectDirs::from("org", "evebox", "evebox")
+        .context("failed to determine a cache directory for suricata-update")?;
+    Ok(directories
+        .cache_dir()
+        .join("oneshot-suricata")
+        .join("local")
+        .join("suricata-update"))
+}
+
+async fn execute_checked(
+    executor: &dyn ProcessExecutor,
+    phase: &str,
+    command: CommandSpec,
+    mode: ExecutionMode,
+) -> Result<()> {
+    debug!("Running local command: {}", command.display());
+    match executor.execute(&command, mode).await {
+        Err(ExecuteError::Interrupted) => anyhow::bail!("{phase} was interrupted"),
+        Err(err) => anyhow::bail!("failed while {phase}: {err}"),
+        Ok(result) if !result.success => failed_command(phase, &command, result),
+        Ok(_) => Ok(()),
+    }
+}
+
+fn failed_command<T>(phase: &str, command: &CommandSpec, result: CommandResult) -> Result<T> {
+    let detail = if !result.stderr.trim().is_empty() {
+        result.stderr.trim()
+    } else {
+        result.stdout.trim()
+    };
+    if !detail.is_empty() {
+        anyhow::bail!("{phase} failed: {detail}");
+    }
+    if let Some(code) = result.code {
+        anyhow::bail!(
+            "{phase} failed: {} exited with status {code}",
+            command.program.to_string_lossy()
+        );
+    }
+    anyhow::bail!(
+        "{phase} failed: {} exited unsuccessfully",
+        command.display()
+    )
+}

--- a/src/cli/oneshot/local/rules.rs
+++ b/src/cli/oneshot/local/rules.rs
@@ -1,0 +1,395 @@
+// SPDX-FileCopyrightText: (C) 2026 Jason Ish <jason@codemonkey.net>
+// SPDX-License-Identifier: MIT
+
+//! Direct rule downloads for local Suricata installations without
+//! `suricata-update`.
+
+use crate::prelude::*;
+
+use flate2::read::GzDecoder;
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io::{BufRead, BufReader, BufWriter, Cursor, Write};
+use std::path::{Component, Path, PathBuf};
+use std::time::{Duration, SystemTime};
+use tar::Archive;
+
+const SOURCE_NAMES: [&str; 3] = ["ET/Open", "PAW Patrules", "The Hunters Ledger Open"];
+
+const PAWPATRULES_URL: &str = "https://rules.pawpatrules.fr/suricata/paw-patrules.tar.gz";
+const HUNTERS_LEDGER_URL: &str =
+    "https://the-hunters-ledger.com/feeds/suricata/hunters-ledger.rules";
+const MAX_ARCHIVE_OUTPUT_BYTES: u64 = 512 * 1024 * 1024;
+const CACHE_MAX_AGE: Duration = Duration::from_secs(15 * 60);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SourceFormat {
+    TarGz,
+    Rules,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RuleSource {
+    name: &'static str,
+    url: String,
+    format: SourceFormat,
+    filename: Option<&'static str>,
+    cache_filename: &'static str,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(super) struct DownloadSummary {
+    pub(super) rule_files: usize,
+    pub(super) archive_files: usize,
+}
+
+pub(super) async fn download_and_merge(
+    version: &semver::Version,
+    rules_directory: &Path,
+    output: &Path,
+) -> Result<DownloadSummary> {
+    let client = reqwest::Client::builder()
+        .user_agent(format!("EveBox/{}", env!("CARGO_PKG_VERSION")))
+        .timeout(Duration::from_secs(120))
+        .build()
+        .context("failed to initialize the direct rule downloader")?;
+    let cache_directory = match cache_directory(version).and_then(|path| {
+        std::fs::create_dir_all(&path).with_context(|| {
+            format!(
+                "failed to create direct rule download cache {}",
+                path.display()
+            )
+        })?;
+        Ok(path)
+    }) {
+        Ok(path) => Some(path),
+        Err(err) => {
+            warn!("Direct rule download cache is unavailable: {err:#}");
+            None
+        }
+    };
+
+    let mut archive_files = 0;
+    for source in rule_sources(version) {
+        let cache_path = cache_directory
+            .as_ref()
+            .map(|directory| directory.join(source.cache_filename));
+        let contents = download_source(&client, &source, cache_path.as_deref()).await?;
+
+        match source.format {
+            SourceFormat::TarGz => {
+                archive_files += extract_tar_gz(&contents, rules_directory)
+                    .with_context(|| format!("failed to extract {} rules", source.name))?;
+            }
+            SourceFormat::Rules => {
+                let filename = source
+                    .filename
+                    .context("direct rule source is missing its output filename")?;
+                std::fs::write(rules_directory.join(filename), contents)
+                    .with_context(|| format!("failed to save downloaded {} rules", source.name))?;
+            }
+        }
+    }
+
+    let rule_files = concatenate_rules(rules_directory, output)?;
+    Ok(DownloadSummary {
+        rule_files,
+        archive_files,
+    })
+}
+
+fn cache_directory(version: &semver::Version) -> Result<PathBuf> {
+    Ok(cache_root(version)?.join("downloads"))
+}
+
+fn cache_root(version: &semver::Version) -> Result<PathBuf> {
+    let directories = directories::ProjectDirs::from("org", "evebox", "evebox")
+        .context("failed to determine a cache directory for local Suricata data")?;
+    Ok(directories
+        .cache_dir()
+        .join("oneshot-suricata")
+        .join("local")
+        .join(format!(
+            "{}.{}.{}",
+            version.major, version.minor, version.patch
+        )))
+}
+
+async fn download_source(
+    client: &reqwest::Client,
+    source: &RuleSource,
+    cache_path: Option<&Path>,
+) -> Result<Vec<u8>> {
+    let cached = if let Some(cache_path) = cache_path {
+        match std::fs::read(cache_path) {
+            Ok(contents) if cache_is_fresh(cache_path) => {
+                info!(
+                    "Using cached {} rules from {}",
+                    source.name,
+                    cache_path.display()
+                );
+                return Ok(contents);
+            }
+            Ok(contents) => Some(contents),
+            Err(_) => None,
+        }
+    } else {
+        None
+    };
+
+    info!("Downloading {} rules from {}", source.name, source.url);
+    let downloaded = async {
+        let response = client
+            .get(&source.url)
+            .send()
+            .await
+            .with_context(|| format!("failed to download {} from {}", source.name, source.url))?
+            .error_for_status()
+            .with_context(|| format!("failed to download {} from {}", source.name, source.url))?;
+        Ok::<_, anyhow::Error>(
+            response
+                .bytes()
+                .await
+                .with_context(|| format!("failed to read downloaded {} rules", source.name))?
+                .to_vec(),
+        )
+    }
+    .await;
+
+    match downloaded {
+        Ok(contents) => {
+            if let Some(cache_path) = cache_path
+                && let Err(err) = std::fs::write(cache_path, &contents)
+            {
+                warn!(
+                    "Failed to cache {} rules at {}: {}",
+                    source.name,
+                    cache_path.display(),
+                    err
+                );
+            }
+            Ok(contents)
+        }
+        Err(err) => {
+            if let Some(cached) = cached {
+                warn!(
+                    "Using stale cached {} rules after download failed: {:#}",
+                    source.name, err
+                );
+                Ok(cached)
+            } else {
+                Err(err)
+            }
+        }
+    }
+}
+
+fn cache_is_fresh(path: &Path) -> bool {
+    std::fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+        .is_some_and(|age| age <= CACHE_MAX_AGE)
+}
+
+fn rule_sources(version: &semver::Version) -> Vec<RuleSource> {
+    vec![
+        RuleSource {
+            name: SOURCE_NAMES[0],
+            url: format!(
+                "https://rules.emergingthreats.net/open/suricata-\
+                 {}.{}.{}/emerging.rules.tar.gz",
+                version.major, version.minor, version.patch
+            ),
+            format: SourceFormat::TarGz,
+            filename: None,
+            cache_filename: "et-open.tar.gz",
+        },
+        RuleSource {
+            name: SOURCE_NAMES[1],
+            url: PAWPATRULES_URL.to_string(),
+            format: SourceFormat::TarGz,
+            filename: None,
+            cache_filename: "pawpatrules.tar.gz",
+        },
+        RuleSource {
+            name: SOURCE_NAMES[2],
+            url: HUNTERS_LEDGER_URL.to_string(),
+            format: SourceFormat::Rules,
+            filename: Some("hunters-ledger.rules"),
+            cache_filename: "hunters-ledger.rules",
+        },
+    ]
+}
+
+fn extract_tar_gz(contents: &[u8], output_directory: &Path) -> Result<usize> {
+    let decoder = GzDecoder::new(Cursor::new(contents));
+    let mut archive = Archive::new(decoder);
+    let mut extracted_bytes: u64 = 0;
+    let mut extracted_files = 0;
+
+    for entry in archive.entries().context("failed to read tar archive")? {
+        let mut entry = entry.context("failed to read tar archive entry")?;
+        if !entry.header().entry_type().is_file() {
+            continue;
+        }
+
+        let archive_path = entry
+            .path()
+            .context("tar archive contains an invalid path")?;
+        let Some(relative_path) = normalized_archive_path(&archive_path)? else {
+            continue;
+        };
+        extracted_bytes = extracted_bytes
+            .checked_add(entry.size())
+            .context("rule archive expanded size overflowed")?;
+        if extracted_bytes > MAX_ARCHIVE_OUTPUT_BYTES {
+            anyhow::bail!(
+                "rule archive expands beyond the {} MiB safety limit",
+                MAX_ARCHIVE_OUTPUT_BYTES / 1024 / 1024
+            );
+        }
+
+        let destination = output_directory.join(relative_path);
+        if let Some(parent) = destination.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "failed to create rule support directory {}",
+                    parent.display()
+                )
+            })?;
+        }
+        let mut output = File::create(&destination).with_context(|| {
+            format!("failed to create extracted file {}", destination.display())
+        })?;
+        std::io::copy(&mut entry, &mut output)
+            .with_context(|| format!("failed to extract file {}", destination.display()))?;
+        extracted_files += 1;
+    }
+
+    Ok(extracted_files)
+}
+
+fn normalized_archive_path(path: &Path) -> Result<Option<PathBuf>> {
+    let mut components = path.components().peekable();
+    if components
+        .peek()
+        .is_some_and(|component| *component == Component::Normal(OsStr::new("rules")))
+    {
+        components.next();
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in components {
+        match component {
+            Component::Normal(name) => normalized.push(name),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                anyhow::bail!("rule archive contains unsafe path {}", path.display());
+            }
+        }
+    }
+    if normalized.as_os_str().is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(normalized))
+    }
+}
+
+fn concatenate_rules(rules_directory: &Path, output: &Path) -> Result<usize> {
+    let mut rule_files = Vec::new();
+    collect_rule_files(rules_directory, output, &mut rule_files)?;
+    rule_files.sort();
+    if rule_files.is_empty() {
+        anyhow::bail!("the downloaded rule sources did not contain any .rules files");
+    }
+
+    let mut merged = BufWriter::new(
+        File::create(output)
+            .with_context(|| format!("failed to create merged rule file {}", output.display()))?,
+    );
+    let mut removed = 0_usize;
+    for rule_file in &rule_files {
+        let mut input = BufReader::new(
+            File::open(rule_file)
+                .with_context(|| format!("failed to open rule file {}", rule_file.display()))?,
+        );
+        let mut line = Vec::new();
+        let mut ends_with_newline = true;
+        loop {
+            line.clear();
+            let read = input
+                .read_until(b'\n', &mut line)
+                .with_context(|| format!("failed to read rule file {}", rule_file.display()))?;
+            if read == 0 {
+                break;
+            }
+            if rule_is_unsupported(&line) {
+                removed += 1;
+                continue;
+            }
+            merged
+                .write_all(&line)
+                .with_context(|| format!("failed to append rule file {}", rule_file.display()))?;
+            ends_with_newline = line.ends_with(b"\n");
+        }
+        if !ends_with_newline {
+            merged.write_all(b"\n")?;
+        }
+    }
+    merged
+        .flush()
+        .with_context(|| format!("failed to finish merged rule file {}", output.display()))?;
+    if removed > 0 {
+        info!(
+            "Removed {removed} rules using the file.magic or filemagic keywords, \
+             which are not supported by Suricata on Windows"
+        );
+    }
+    Ok(rule_files.len())
+}
+
+/// The Windows Suricata builds do not include libmagic, so rules using the
+/// file.magic or filemagic keywords fail to load there. Commented rules are
+/// kept as they are inert.
+fn rule_is_unsupported(line: &[u8]) -> bool {
+    if !cfg!(windows) {
+        return false;
+    }
+    if line.iter().find(|byte| !byte.is_ascii_whitespace()) == Some(&b'#') {
+        return false;
+    }
+    [b"file.magic".as_slice(), b"filemagic".as_slice()]
+        .iter()
+        .any(|keyword| line.windows(keyword.len()).any(|window| window == *keyword))
+}
+
+fn collect_rule_files(
+    directory: &Path,
+    output: &Path,
+    rule_files: &mut Vec<PathBuf>,
+) -> Result<()> {
+    for entry in std::fs::read_dir(directory)
+        .with_context(|| format!("failed to read rule directory {}", directory.display()))?
+    {
+        let entry = entry.with_context(|| {
+            format!(
+                "failed to read an entry in rule directory {}",
+                directory.display()
+            )
+        })?;
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("failed to inspect extracted rule path {}", path.display()))?;
+        if file_type.is_dir() {
+            collect_rule_files(&path, output, rule_files)?;
+        } else if file_type.is_file()
+            && path != output
+            && path.extension() == Some(OsStr::new("rules"))
+        {
+            rule_files.push(path);
+        }
+    }
+    Ok(())
+}

--- a/src/cli/oneshot/process.rs
+++ b/src/cli/oneshot/process.rs
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: (C) 2026 Jason Ish <jason@codemonkey.net>
+// SPDX-License-Identifier: MIT
+
+use anyhow::Context;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct CommandSpec {
+    pub(super) program: OsString,
+    pub(super) args: Vec<OsString>,
+    pub(super) current_dir: Option<PathBuf>,
+}
+
+impl CommandSpec {
+    pub(super) fn new(
+        program: impl Into<OsString>,
+        args: impl IntoIterator<Item = impl Into<OsString>>,
+    ) -> Self {
+        Self {
+            program: program.into(),
+            args: args.into_iter().map(Into::into).collect(),
+            current_dir: None,
+        }
+    }
+
+    pub(super) fn with_current_dir(mut self, directory: impl Into<PathBuf>) -> Self {
+        self.current_dir = Some(directory.into());
+        self
+    }
+
+    pub(super) fn display(&self) -> String {
+        std::iter::once(&self.program)
+            .chain(self.args.iter())
+            .map(|arg| arg.to_string_lossy())
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) enum ExecutionMode {
+    /// Capture output, keeping command chatter out of the user's terminal.
+    Capture,
+    /// Show live output and stop the child process on Ctrl-C.
+    Interruptible,
+}
+
+#[derive(Debug)]
+pub(super) struct CommandResult {
+    pub(super) success: bool,
+    pub(super) code: Option<i32>,
+    pub(super) stdout: String,
+    pub(super) stderr: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(super) enum ExecuteError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error("interrupted")]
+    Interrupted,
+}
+
+#[async_trait::async_trait]
+pub(super) trait ProcessExecutor: Send + Sync {
+    async fn execute(
+        &self,
+        command: &CommandSpec,
+        mode: ExecutionMode,
+    ) -> Result<CommandResult, ExecuteError>;
+}
+
+pub(super) struct TokioProcessExecutor;
+
+#[async_trait::async_trait]
+impl ProcessExecutor for TokioProcessExecutor {
+    async fn execute(
+        &self,
+        command: &CommandSpec,
+        mode: ExecutionMode,
+    ) -> Result<CommandResult, ExecuteError> {
+        let mut process = tokio::process::Command::new(&command.program);
+        process.args(&command.args).stdin(Stdio::null());
+        if let Some(directory) = &command.current_dir {
+            process.current_dir(directory);
+        }
+
+        if matches!(mode, ExecutionMode::Capture) {
+            process.kill_on_drop(true);
+            let output = tokio::select! {
+                output = process.output() => output?,
+                signal = tokio::signal::ctrl_c() => {
+                    signal?;
+                    return Err(ExecuteError::Interrupted);
+                }
+            };
+            return Ok(CommandResult {
+                success: output.status.success(),
+                code: output.status.code(),
+                stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            });
+        }
+
+        process.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+        let mut child = process.kill_on_drop(true).spawn()?;
+        let status = tokio::select! {
+            status = child.wait() => status?,
+            signal = tokio::signal::ctrl_c() => {
+                signal?;
+                let _ = child.kill().await;
+                return Err(ExecuteError::Interrupted);
+            }
+        };
+
+        Ok(CommandResult {
+            success: status.success(),
+            code: status.code(),
+            stdout: String::new(),
+            stderr: String::new(),
+        })
+    }
+}
+
+pub(super) fn path(value: impl AsRef<Path>) -> OsString {
+    value.as_ref().as_os_str().to_os_string()
+}
+
+pub(super) fn validate_eve_output(output: &Path) -> anyhow::Result<()> {
+    let metadata = std::fs::metadata(output).with_context(|| {
+        format!(
+            "Suricata completed but did not produce a readable eve.json at {}",
+            output.display()
+        )
+    })?;
+    if !metadata.is_file() {
+        anyhow::bail!(
+            "Suricata output is not a regular eve.json file: {}",
+            output.display()
+        );
+    }
+    std::fs::File::open(output).with_context(|| {
+        format!(
+            "Suricata produced an unreadable eve.json at {}",
+            output.display()
+        )
+    })?;
+    Ok(())
+}

--- a/src/server/pcap/mod.rs
+++ b/src/server/pcap/mod.rs
@@ -173,7 +173,7 @@ impl PcapService {
         self.routing.read().unwrap().clone()
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, not(windows)))]
     pub(crate) fn source(&self) -> Option<&PcapSource> {
         self.source.as_ref()
     }
@@ -454,7 +454,10 @@ mod test {
         crate::config::Config::new(args, path.to_str()).unwrap()
     }
 
+    /// Server-local spool sources are not supported on Windows, where
+    /// configure() ignores pcap.directory.
     #[test]
+    #[cfg(not(windows))]
     fn test_configure_local_spool() {
         let dir = tempfile::tempdir().unwrap();
         let yaml = format!("pcap:\n  directory: {}\n", dir.path().display());
@@ -476,6 +479,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(windows))]
     fn test_configure_normalizes_blank_and_padded_strings() {
         let dir = tempfile::tempdir().unwrap();
         let config = yaml_config(


### PR DESCRIPTION
- **misc: suppress index drop notes on initial migration**
  They are just noise on an initial install, or in oneshot mode.
  

- **oneshot: support a locally installed Suricata for PCAP processing**
  - Add a local Suricata backend for --pcap that uses a user installed
    Suricata. Linux defaults to the container backend; Windows defaults
    to the local backend. Select explicitly with --suricata-backend,
    --suricata, or --suricata-update.
  - Download rules with suricata-update when available, or directly from
    the supported rule feeds when it is absent, such as on Windows.
    Downloads are cached in the EveBox cache directory.
  - Generate all Suricata and suricata-update configuration in a private
    temporary workspace, leaving the installed Suricata configuration
    untouched.
  - Require Suricata 8.0.0 or newer for the local backend.
  - Stop passing --init-errors-fatal to Suricata in both backends: bad
    rules are now skipped with warnings instead of failing the run.
  - Windows supports analysis and event import, but not packet
    extraction. Hide --suricata-update from the help output on Windows,
    where suricata-update is not available.
  - Move the process execution helpers shared by the container and local
    backends into src/cli/oneshot/process.rs.
  

- **ci: run tests natively on Windows**
  The oneshot local Suricata backend adds Windows-specific code paths,
  so run the test suite on a native Windows runner.
  